### PR TITLE
Fix the issue with OPTIONS method

### DIFF
--- a/remind_me/generic/decorators.py
+++ b/remind_me/generic/decorators.py
@@ -1,0 +1,15 @@
+from functools import wraps
+
+from rest_framework.response import Response
+
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(request, *args, **kwargs):
+        if not hasattr(request, 'user'):
+            return Response("Please login to continue")
+        else:
+            if not hasattr(request.user, 'customer'):
+                return Response("Please login to continue")
+        return f(request, *args, **kwargs)
+    return decorated

--- a/remind_me/remind_me/settings.py
+++ b/remind_me/remind_me/settings.py
@@ -100,7 +100,7 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.AllowAny',
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': (
        'rest_framework.authentication.TokenAuthentication',

--- a/remind_me/reminders/views.py
+++ b/remind_me/reminders/views.py
@@ -1,4 +1,5 @@
 import logging
+from django.utils.decorators import method_decorator
 
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -7,14 +8,15 @@ from rest_framework import status
 from reminders.serializers import ReminderSerializer
 from reminders.models import Reminder
 from generic.utils import get_data_from_request
+from generic.decorators import requires_auth
 
 logger = logging.getLogger(__name__)
 
 
 class Reminders(APIView):
 
-    @staticmethod
-    def post(request):
+    @method_decorator(requires_auth)
+    def post(self, request):
         data = get_data_from_request(request)
         serializer = ReminderSerializer(data=data)
         customer = request.user.customer
@@ -26,8 +28,8 @@ class Reminders(APIView):
         logger.error("Invalid data in request from {0} : {1}".format(customer, serializer.errors))
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    @staticmethod
-    def get(request, id=None):
+    @method_decorator(requires_auth)
+    def get(self, request, id=None):
         if id is None:
             reminders = request.user.customer.reminders.all()
             serializer = ReminderSerializer(reminders, many=True)
@@ -44,8 +46,8 @@ class Reminders(APIView):
                     return Response(data=serializer.data)
                 return Response(status=status.HTTP_403_FORBIDDEN)
 
-    @staticmethod
-    def delete(request, id):
+    @method_decorator(requires_auth)
+    def delete(self, request, id):
         try:
             reminder = Reminder.objects.get(id=int(id))
         except Reminder.DoesNotExist:
@@ -57,8 +59,8 @@ class Reminders(APIView):
                 return Response(status=status.HTTP_204_NO_CONTENT)
             return Response(status=status.HTTP_403_FORBIDDEN)
 
-    @staticmethod
-    def put(request, id):
+    @method_decorator(requires_auth)
+    def put(self, request, id):
         try:
             reminder = Reminder.objects.get(id=int(id))
         except Reminder.DoesNotExist:


### PR DESCRIPTION
## DESCRIPTION

### CONTEXT
OPTIONS request made by the browser are failing because browser doesn't sets token or associate OPTIONS request with any kind of authentication.

### GOAL
**_Fix the issue with OPTIONS method_**

### IMPLEMENTATION
Changed the default permission class for REST APIs to AllowAny so that authenticated and unauthenticated requests are allowed.
Add a decorator for allowing authenticated requests only and apply this decorator over all the necessary API methods.